### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-model</artifactId>
+            <version>${mule.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/test/java/org/mule/extensions/vm/test/VMTestCase.java
+++ b/src/test/java/org/mule/extensions/vm/test/VMTestCase.java
@@ -38,8 +38,7 @@ import javax.inject.Named;
 
 import org.junit.Rule;
 
-@ArtifactClassLoaderRunnerConfig(exportPluginClasses = VMConnectorQueueManager.class,
-    sharedRuntimeLibs = {"org.mule.tests:mule-tests-unit"})
+@ArtifactClassLoaderRunnerConfig(exportPluginClasses = VMConnectorQueueManager.class)
 public abstract class VMTestCase extends MuleArtifactFunctionalTestCase {
 
   protected static final String STRING_PAYLOAD = "Hello";


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts