### PR TITLE
W-14625512 | Release 2.0.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mulesoft/team-connectivity-infrastructure

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+_Hi, thank you for your work. We understand that you want to merge your changes and move on from this issue, but we also want to maintain the safety, readability, and testability of our code. Because of this, we kindly ask that you confirm that you have fulfilled the prerequisites for each category of activity before merging your changes._
+
+### If the Pull Request has a dependency update:
+
+- [ ] I have read the Release Notes for the new version (and intermediate versions if the jump would include more than one). _Don't blindly trust that the dependency will honor SEMVER, always read carefully the release notes_
+- [ ] Java 8+ support is maintained
+- [ ] The new version has no vulnerabilities
+- [ ] A team member reviewed the Pull Request.
+- [ ] No backward compatibility is broken.
+- [ ] If it is a "provided" dependency, it has been checked that if it is suggested, the version number is the same.
+
+### For ALL the Releases:
+
+- [ ] There is a task in GUS for this change.
+- [ ] The corresponding Release Notes have been written and shared with the documentation team.
+- [ ] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.
+- [ ] If you are using reflection, create a test to call the methods you are invoking, this way, if there is a change in the API, the test will be able to detect it.
+- [ ] If the project has a parent pom and modules, the release pipeline only uploads the modules, so, please, make sure that the parent was deployed in the repositories before considering this release finished.
+- [ ] Notify in the Slack Channel that the release is complete, so the Docs team can merge the Documentation and Release Notes PR. The docs team always checks in Anypoint Exchange that the connector is released before merging the release notes.
+- [ ] Add the connector build to GUS, and assign that build to the GUS ticket.
+- [ ] Create a change case request, based on the Change Case Management doc https://docs.google.com/document/d/1tMJlTTZLaXMLiYwxlMBFY1yJwBmejhc4-IP8HAXgDfY/edit#
+
+**NOTE**: _(applies only for Core-Connectors connectors and modules) The release process ends when you merge the pull request that updates the support branch to the new snapshot, please don't forget to do this._
+
+### Patch Version:
+
+- [ ] The Pull Request has been peer-reviewed.
+- [ ] No backward compatibility is broken.
+- [ ] Documentation: (Required) Release Notes PR with compatibility table. Share it with the Docs team.
+
+### Minor Version:
+
+- [ ] Have a document with the specification of the release.
+- [ ] Create a slack channel (eg: rl-conninfra-sftp-1.1.1-new-chiper) to coordinate the release of this version with the documentation team and the architects of our team (at least one week before the release). Share the spec doc with the docs team.
+- [ ] The documentation fork has been done and has been updated with the changes related to the new functionalities.
+- [ ] The pull request has been reviewed by a peer and the team leader.
+- [ ] No backward compatibility is broken.
+- [ ] Public Documentation: Minor releases nearly always require a revision of the documentation because the release usually includes new features as well as bug fixes. Even if there are no user-facing changes, documentation has to be versioned for every minor release.
+  - [ ] (Required) Release Notes PR with compatibility table. Share it with the Docs team.
+  - [ ] (Likely required) Reference guide. Run the script and share the file with the Docs team.
+  - [ ] (Assess) Often a minor release impacts UI and examples, so the documentation (user guides, examples, troubleshooting guides) should be reviewed and updated accordingly. Notify the docs team if any updates are needed.
+
+### Major Version:
+
+- [ ] Have a document with the specification of the release.
+- [ ] Create a slack channel (eg: rl-conninfra-sftp-2.0.0) to coordinate the release of this version with the documentation team and the architects of our team (at least one month before the release). Share the spec doc with the docs team.
+- [ ] The documentation fork has been made and updated with the changes related to the new functionalities and possible compatibility problems with the previous version.
+- [ ] The systems properties have been removed, detailing in the documentation the changes in the default behavior of the product.
+- [ ] The TODO comments of the code have been reviewed.
+- [ ] A colleague, the team leader, and the team architect have reviewed the Pull Request.
+- [ ] Public Documentation: Major releases break backward compatibility and should never be released without documentation, as this breaks the user experience.
+  - [ ] (Required) Upgrade and Migration Guide: Every major release must have a detailed upgrade guide (template) with information about what was changed and what steps the user has to take to ensure the connector works as expected. Share the details with the Docs team so they can update the guide.
+  - [ ] (Required) Release Notes PR with compatibility table. Share it with the docs team.
+  - [ ] (Required) Reference guide. Run the script and share the file with the Docs team.
+  - [ ] User guide updates, new screenshots or examples (if applicable), share the updates with the docs team.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "branchPrefix": "renovate-",
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 10,
+  "schedule": [
+    "after 8pm and before 8am on every weekday",
+    "every weekend"
+  ],
+  "timezone": "America/Argentina/Buenos_Aires",
+  "ignoreDeps": [
+    "org.mule.extensions:mule-core-modules-parent"
+  ]
+}

--- a/build.yaml
+++ b/build.yaml
@@ -5,4 +5,4 @@ additionalTestConfigs:
     mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.3.0
   jdk17:
     testJdkTool: OPEN-JDK17
-    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.6.0 -DruntimeVersion=4.6.0-rc2 -DruntimeProduct=MULE_EE
+    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.6.0 -DruntimeVersion=4.6.0-rc2 -DruntimeProduct=MULE_EE -Dmule.jvm.version.extension.enforcement=LOOSE

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ projectType: extension
 additionalTestConfigs:
   jdk11:
     testJdkTool: OPEN-JDK11
-    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.3.0
+    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.3.0 -DruntimeVersion=4.4.0 -DruntimeProduct=MULE_EE
   jdk17:
     testJdkTool: OPEN-JDK17
     mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.6.0 -DruntimeVersion=4.6.0-rc2 -DruntimeProduct=MULE_EE -Dmule.jvm.version.extension.enforcement=LOOSE

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,7 @@
+projectType: extension
+additionalTestConfigs:
+  jdk11:
+    testJdkTool: OPEN-JDK11
+  jdk17:
+    testJdkTool: OPEN-JDK17
+    mavenAdditionalArgs: -DdiscoverRuntimes.minMuleVersion=4.6.0

--- a/build.yaml
+++ b/build.yaml
@@ -2,6 +2,7 @@ projectType: extension
 additionalTestConfigs:
   jdk11:
     testJdkTool: OPEN-JDK11
+    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.3.0
   jdk17:
     testJdkTool: OPEN-JDK17
-    mavenAdditionalArgs: -DdiscoverRuntimes.minMuleVersion=4.6.0
+    mavenAdditionalArgs: -Dtest=none -DfailIfNoTests=false -DminVersion=4.6.0 -DruntimeVersion=4.6.0-rc2 -DruntimeProduct=MULE_EE

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-vm-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>2.0.1</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>VM Connector</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-vm-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
 
     <name>VM Connector</name>
     <description>
@@ -24,6 +24,27 @@
     <properties>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <muleTestsComponentPlugin>${mule.version}</muleTestsComponentPlugin>
+
+        <jacoco.version>0.8.10</jacoco.version>
+        <mavenResources.version>3.0.2</mavenResources.version>
+
+        <munit.input.directory>src/test/munit</munit.input.directory>
+        <munit.citizen.input.directory>src/test/munit-citizen</munit.citizen.input.directory>
+        <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
+        <munit.extensions.maven.plugin.version>1.2.0-rc2</munit.extensions.maven.plugin.version>
+        <munit.version>3.1.0-rc3</munit.version>
+        <mtf.tools.version>1.2.0-rc1</mtf.tools.version>
+
+        <mtf.javaopts></mtf.javaopts>
+
+        <mule.http.connector.version>1.9.0</mule.http.connector.version>
+        <mule.sockets.connector.version>1.2.4</mule.sockets.connector.version>
+        <mule.java.module.version>1.2.12</mule.java.module.version>
+        <mule.objectstore.connector.version>1.2.2</mule.objectstore.connector.version>
+        <mule.scripting.module.version>2.1.0</mule.scripting.module.version>
+
+        <!-- runtime version to run MUnit tests-->
+        <runtimeVersion>4.1.1</runtimeVersion>
     </properties>
 
     <distributionManagement>
@@ -41,6 +62,216 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jdkinternals</goal> <!-- verify main classes -->
+                            <goal>test-jdkinternals</goal> <!-- verify test classes -->
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnWarning>true</failOnWarning>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${dir.javaLibs}</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${mavenResources.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-munit-resources</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${munit.output.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${munit.input.directory}</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>${munit.citizen.input.directory}</directory>
+                                    <includes>
+                                        <include>CitizenCommonFlows.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.mulesoft.munit</groupId>
+                <artifactId>munit-extensions-maven-plugin</artifactId>
+                <version>${munit.extensions.maven.plugin.version}</version>
+                <configuration>
+                    <runtimeProduct>MULE_EE</runtimeProduct>
+                    <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                    <argLines>
+                        <argLine>
+                            -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco-munit.exec
+                        </argLine>
+                    </argLines>
+                    <environmentVariables>
+                        <!-- Toggles the JDK17 style flag -->
+                        <!-- ugly hack -->
+                        <_JAVA_OPTIONS>-XX:+PrintCommandLineFlags ${mtf.javaopts}</_JAVA_OPTIONS>
+                    </environmentVariables>
+                    <sharedLibraries>
+                        <sharedLibrary>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-all</artifactId>
+                        </sharedLibrary>
+                    </sharedLibraries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-runner</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-tools</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mule.connectors</groupId>
+                        <artifactId>mule-http-connector</artifactId>
+                        <version>${mule.http.connector.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mule.connectors</groupId>
+                        <artifactId>mule-sockets-connector</artifactId>
+                        <version>${mule.sockets.connector.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>mtf-tools</artifactId>
+                        <version>${mtf.tools.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mule.module</groupId>
+                        <artifactId>mule-java-module</artifactId>
+                        <version>${mule.java.module.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mule.connectors</groupId>
+                        <artifactId>mule-objectstore-connector</artifactId>
+                        <version>${mule.objectstore.connector.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mule.modules</groupId>
+                        <artifactId>mule-scripting-module</artifactId>
+                        <version>${mule.scripting.module.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-all</artifactId>
+                        <version>2.4.21</version>
+                        <classifier>indy</classifier>
+                    </dependency>
+                    <!-- Needs minMuleVersion 4.4.0 -->
+                    <dependency>
+                        <groupId>org.mule.modules</groupId>
+                        <artifactId>mule-tracing-module</artifactId>
+                        <version>1.0.0</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <destFile>${session.executionRootDirectory}/target/jacoco.exec</destFile>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${session.executionRootDirectory}/target</directory>
+                            <includes>
+                                <include>*.exec</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>merge</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${session.executionRootDirectory}/target/jacoco.exec</destFile>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>*.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>
@@ -54,6 +285,17 @@
             <artifactId>mule-tests-model</artifactId>
             <version>${mule.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.weave</groupId>
+            <artifactId>assertions</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.sdk</groupId>
+            <artifactId>mule-sdk-api</artifactId>
+            <version>0.7.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/mule/extensions/vm/internal/VMConnector.java
+++ b/src/main/java/org/mule/extensions/vm/internal/VMConnector.java
@@ -32,6 +32,12 @@ import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.RefName;
 import org.mule.runtime.extension.api.runtime.parameter.OutboundCorrelationStrategy;
 
+import org.mule.sdk.api.annotation.JavaVersionSupport;
+
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_8;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_11;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_17;
+
 import javax.inject.Inject;
 
 import java.util.List;
@@ -61,6 +67,7 @@ import java.util.List;
 @Operations(VMOperations.class)
 @ConnectionProviders(VMConnectionProvider.class)
 @ErrorTypes(VMError.class)
+@JavaVersionSupport({JAVA_8, JAVA_11, JAVA_17})
 public class VMConnector implements Startable, Stoppable {
 
   @Inject

--- a/src/test/munit/Config.xml
+++ b/src/test/munit/Config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+
+    <vm:config name="VM_Config">
+        <vm:queues >
+            <vm:queue queueName="transientQueue" queueType="TRANSIENT" />
+            <vm:queue queueName="persistentQueue" queueType="PERSISTENT" />
+        </vm:queues>
+    </vm:config>
+
+    <vm:config name="sync">
+        <vm:queues>
+            <vm:queue queueName="synchronousQueue" queueType="PERSISTENT" />
+        </vm:queues>
+    </vm:config>
+
+    <vm:config name="onError">
+        <vm:queues>
+            <vm:queue queueName="onErrorPropagate" queueType="PERSISTENT" />
+        </vm:queues>
+    </vm:config>
+
+</mule>

--- a/src/test/munit/QueueNamesValueProviderTestCase.xml
+++ b/src/test/munit/QueueNamesValueProviderTestCase.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/mtf  http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
+
+    <munit:config name="QueueNamesValueProviderTestCase.xml" />
+
+    <mtf:tooling-test name="get-queue-names-test" description="Test that value provider works">
+        <mtf:get-values parameter="queueName" >
+            <vm:publish config-ref="VM_Config" queueName="persistentQueue">
+                <vm:content >
+                    <![CDATA[#["publish message"]]]>
+                </vm:content>
+            </vm:publish>
+        </mtf:get-values>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[
+            %dw 2.0
+            output application/json
+            var queues = payload pluck $$ as String
+            ---
+            queues == ['transientQueue','persistentQueue']
+            ]"
+                                     is="#[MunitTools::equalTo(true)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+</mule>

--- a/src/test/munit/VMConsumeFromQueueWithListenerTestCase.xml
+++ b/src/test/munit/VMConsumeFromQueueWithListenerTestCase.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
+
+    <munit:config name="VMConsumeFromQueueWithListenerTestCase.xml" />
+
+    <munit:test name="consume-from-queue-with-listener-test" description="Test that consuming from a queue with listener throws exception" expectedErrorType="MULE:UNKNOWN" expectedErrorDescription="Operation &apos;&lt;vm:consume&gt;&apos; in Flow &apos;consume-from-queue-with-listener-test&apos; is trying to consume from queue &apos;transientQueue&apos;, but Flow &apos;listener-transient-queue&apos; defines a &lt;vm:listener&gt; on that queue. It's not allowed to consume from a queue on which a listener already exists">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="listener-transient-queue" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <vm:consume queueName="transientQueue" config-ref="VM_Config" />
+        </munit:execution>
+    </munit:test>
+
+    <flow name="listener-transient-queue" >
+        <vm:listener config-ref="VM_Config" queueName="transientQueue"/>
+        <logger />
+    </flow>
+
+</mule>

--- a/src/test/munit/VMConsumeTestCase.xml
+++ b/src/test/munit/VMConsumeTestCase.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
+
+    <munit:config name="VMConsumeTestCase.xml" />
+
+    <munit:test name="consume-typed-value-test" description="Test the consume operation on a transient queue">
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+            <flow-ref name="publish-transient-flow"/>
+        </munit:behavior>
+        <munit:execution>
+            <vm:consume queueName="transientQueue" config-ref="VM_Config" />
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo(vars.payload)]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="empty-queue-test" expectedErrorType="VM:EMPTY_QUEUE" description="Test the consume operation on an empty queue and expect an exception to be thrown">
+        <munit:execution>
+            <vm:consume queueName="transientQueue" config-ref="VM_Config" />
+        </munit:execution>
+    </munit:test>
+
+    <flow name="publish-transient-flow">
+        <vm:publish queueName="transientQueue" config-ref="VM_Config">
+            <vm:content>#[vars.payload]</vm:content>
+        </vm:publish>
+    </flow>
+
+</mule>

--- a/src/test/munit/VMListenerTestCase.xml
+++ b/src/test/munit/VMListenerTestCase.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting"
+        xmlns:os="http://www.mulesoft.org/schema/mule/os"
+        xmlns:java="http://www.mulesoft.org/schema/mule/java"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/java http://www.mulesoft.org/schema/mule/java/current/mule-java.xsd
+http://www.mulesoft.org/schema/mule/os http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd
+http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd">
+
+    <munit:config name="VMListenerTestCase.xml" />
+
+    <os:object-store name="Object_store" doc:name="Object store" doc:id="8148f428-08ba-4117-8f2d-ba7940013825" />
+
+    <munit:test name="listen-on-transient-queue-test" description="Test the VMListener with a transient queue">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <java:new class="java.lang.String" constructor="String(java.lang.String)">
+                <java:args ><![CDATA[#["arg0": "message"]]]></java:args>
+            </java:new>
+            <munit-tools:queue queueName="transientQueue">
+                <munit-tools:value>#[payload]</munit-tools:value>
+            </munit-tools:queue>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::equalTo('message')]"/>
+            <munit-tools:assert-that expression="#[payload.payloadMimeType]"
+                                     is="#[MunitTools::equalTo('application/java')]"/>
+            <munit-tools:assert-that expression="#[payload.payloadClassType]"
+                                     is="#[MunitTools::equalTo('java.lang.String')]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('transientQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="listen-one-at-a-time-test" description="Test the Listener in a synchronous scenario">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_synchronousListener" />
+        </munit:enable-flow-sources>
+        <munit:behavior >
+            <os:store doc:name="Store" doc:id="5957fc78-d358-4fd0-8dbf-ea544ae3e3ad" key="timestamps" objectStore="Object_store">
+                <os:value ><![CDATA[#[[]]]]></os:value>
+            </os:store>
+        </munit:behavior>
+        <munit:execution>
+            <set-payload value="#['message']"/>
+            <foreach collection="#[1 to 3]">
+                <flow-ref name="VM_publishToSyncQueue"/>
+            </foreach>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <os:retrieve doc:name="Retrieve" doc:id="8fd9e44c-8e18-4552-a577-1055374c6ec4" key="timestamps" objectStore="Object_store"/>
+                <munit-tools:assert-that expression="#[payload]"
+                                         is="#[MunitTools::hasSize(MunitTools::equalTo(3))]"/>
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload[2]]"
+                                     is="#[MunitTools::greaterThan(payload[1])]"/>
+            <munit-tools:assert-that expression="#[payload[1]]"
+                                     is="#[MunitTools::greaterThan(payload[0])]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="listen-on-persistent-queue-test" description="Test the VMListener with a persistent queue">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-persistent-queue-flow" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <java:new class="java.lang.String" constructor="String(java.lang.String)">
+                <java:args ><![CDATA[#["arg0": "message"]]]></java:args>
+            </java:new>
+            <flow-ref name="VM_publishToPersistentQueueFlow"/>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::equalTo('message')]"/>
+            <munit-tools:assert-that expression="#[payload.payloadMimeType]"
+                                     is="#[MunitTools::equalTo('application/java')]"/>
+            <munit-tools:assert-that expression="#[payload.payloadClassType]"
+                                     is="#[MunitTools::equalTo('java.lang.String')]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('persistentQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="consumers-stopped-test" expectedErrorType="MUNIT-TOOLS:MISSING_KEY" description="Test no event is created when using a stopped flow with a VM Listener">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <scripting:execute engine="groovy" >
+                <scripting:code >
+                    <![CDATA[
+                        flow = registry.lookupByName("vm-listener-transient-queue-flow").get();
+                        if (flow.isStarted())
+	                        flow.stop()
+                    ]]>
+                </scripting:code>
+            </scripting:execute>
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish queueName="transientQueue" config-ref="VM_Config" >
+                <vm:content><![CDATA[#["message"]]]></vm:content>
+            </vm:publish>
+            <until-successful maxRetries="5"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+    </munit:test>
+
+    <flow name="vm-listener-transient-queue-flow">
+        <vm:listener config-ref="VM_Config" queueName="transientQueue"/>
+        <munit-tools:store key="listenerData">
+            <munit-tools:value ><![CDATA[#[
+            output application/json
+            ---
+            {
+                "payload": payload,
+                "payloadMimeType": payload.^mimeType,
+                "payloadClassType": payload.^class,
+                "attributes": message.attributes,
+                "attributesClassType": message.attributes.^class
+            }
+            ]]]></munit-tools:value>
+        </munit-tools:store>
+    </flow>
+
+    <flow name="vm-listener-persistent-queue-flow" >
+        <vm:listener config-ref="VM_Config" queueName="persistentQueue"/>
+        <munit-tools:store key="listenerData">
+            <munit-tools:value ><![CDATA[#[
+            output application/json
+            ---
+            {
+                "payload": payload,
+                "payloadMimeType": payload.^mimeType,
+                "payloadClassType": payload.^class,
+                "attributes": message.attributes,
+                "attributesClassType": message.attributes.^class
+            }
+            ]]]></munit-tools:value>
+        </munit-tools:store>
+    </flow>
+
+    <flow name="VM_publishToSyncQueue">
+        <vm:publish queueName="synchronousQueue" config-ref="sync" transactionalAction="JOIN_IF_POSSIBLE"/>
+    </flow>
+
+    <flow name="VM_publishToPersistentQueueFlow">
+        <vm:publish queueName="persistentQueue" config-ref="VM_Config" />
+    </flow>
+
+    <flow name="VM_synchronousListener" maxConcurrency="1">
+        <vm:listener queueName="synchronousQueue" numberOfConsumers="1" config-ref="sync" transactionalAction="ALWAYS_BEGIN"/>
+        <os:retrieve doc:name="Retrieve" doc:id="8e2f31e9-f101-4b82-a941-2bd971c00ddd" key="timestamps" objectStore="Object_store"/>
+        <os:store doc:name="Store" doc:id="243ada9b-76fa-46c7-9d06-9c71806c2f3f" objectStore="Object_store" key="timestamps">
+            <os:value ><![CDATA[#[payload as Array ++ [now() as String {format: 'y-MM-dd:hh:mm:ss:SSS'}]]]]></os:value>
+        </os:store>
+    </flow>
+
+</mule>

--- a/src/test/munit/VMPublishConsumeTestCase.xml
+++ b/src/test/munit/VMPublishConsumeTestCase.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:tracing="http://www.mulesoft.org/schema/mule/tracing"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/tracing http://www.mulesoft.org/schema/mule/tracing/current/mule-tracing.xsd">
+
+    <munit:config name="VMPublishConsumeTestCase.xml"/>
+
+    <munit:test name="publish-consume-test" description="Test the publish-consume operation with a transient queue">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="VM_listener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish-consume queueName="transientQueue" config-ref="VM_Config">
+                <vm:content ><![CDATA[#[vars.payload]]]></vm:content>
+            </vm:publish-consume>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- Works only with minMuleVersion 4.4.0 -->
+    <munit:test name="transactional-publish-consume-test"  description="Test the publish-consume operation with a transient queue in a transactional try block">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="VM_listener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <!-- Works only with minMuleVersion 4.4.0 and MUnit 2.3.13 -->
+            <try transactionalAction="ALWAYS_BEGIN">
+                <vm:publish-consume queueName="transientQueue" config-ref="VM_Config">
+                    <vm:content ><![CDATA[#[vars.payload]]]></vm:content>
+                </vm:publish-consume>
+            </try>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test ignore="false" name="publish-consume-with-default-correlation-id-test" description="Test the publish-consume operation with the default correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_listener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <tracing:with-correlation-id correlationId="#['myCorrelationId']">
+                <vm:publish-consume queueName="transientQueue" config-ref="VM_Config">
+                    <vm:content><![CDATA[#[vars.payload]]]></vm:content>
+                </vm:publish-consume>
+            </tracing:with-correlation-id>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[message.attributes.correlationId]"
+                                     is="#[MunitTools::equalTo('myCorrelationId')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-consume-with-custom-correlation-id-test" description="Test the publish-consume operation with a custom correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_listener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish-consume queueName="transientQueue" correlationId="myCustomCorrelationId" config-ref="VM_Config">
+                <vm:content><![CDATA[#[vars.payload]]]></vm:content>
+            </vm:publish-consume>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+            <munit-tools:assert-that expression="#[message.attributes.correlationId]"
+                                     is="#[MunitTools::equalTo('myCustomCorrelationId')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="never-send-correlation-id-test" description="Test the publish-consume operation and never send a correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_listener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish-consume queueName="transientQueue" correlationId="myCustomCorrelationId" sendCorrelationId="NEVER" config-ref="VM_Config">
+                <vm:content><![CDATA[#[vars.payload]]]></vm:content>
+            </vm:publish-consume>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+            <munit-tools:assert-that expression="#[message.attributes.correlationId]"
+                                     is="#[MunitTools::not(MunitTools::equalTo('myCustomCorrelationId'))]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="on-error-continue-test" description="Test behavior with on-error-continue when exception is thrown">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_onErrorContinueListener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "salute": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+            <munit-tools:mock-when processor="mule:set-variable">
+                <munit-tools:then-return >
+                    <munit-tools:error typeId="VM:PUBLISH_CONSUMER_FLOW_ERROR" />
+                </munit-tools:then-return>
+            </munit-tools:mock-when>
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish-consume queueName="transientQueue" config-ref="VM_Config">
+                <vm:content><![CDATA[#[vars.payload]]]></vm:content>
+            </vm:publish-consume>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:verify-call processor="mule:logger"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo('hello')]"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="on-error-propagate-test" description="Test behavior with on-error-propagate when exception is thrown">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="VM_onErrorPropagateListener" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <munit-tools:mock-when processor="mule:set-variable">
+                <munit-tools:then-return >
+                    <munit-tools:error typeId="VM:PUBLISH_CONSUMER_FLOW_ERROR" />
+                </munit-tools:then-return>
+            </munit-tools:mock-when>
+        </munit:behavior>
+        <munit:execution>
+            <try>
+                <vm:publish-consume queueName="onErrorPropagate" config-ref="onError">
+                    <vm:content><![CDATA[#["hello"]]]></vm:content>
+                </vm:publish-consume>
+                <error-handler >
+                    <on-error-continue type="VM:PUBLISH_CONSUMER_FLOW_ERROR"/>
+                </error-handler>
+            </try>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:verify-call processor="mule:logger"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-to-failing-queue-test" expectedErrorType="VM:PUBLISH_CONSUMER_FLOW_ERROR" description="Test behavior on a flow with failing queue">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="VM_failListener" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <vm:publish-consume queueName="persistentQueue" config-ref="VM_Config"/>
+        </munit:execution>
+    </munit:test>
+
+    <flow name="VM_listener" initialState="stopped">
+        <vm:listener queueName="transientQueue" config-ref="VM_Config">
+            <vm:response>
+                <vm:content>
+                    #[lower(payload.salute)]
+                </vm:content>
+            </vm:response>
+        </vm:listener>
+        <munit-tools:store key="listenerData"/>
+    </flow>
+
+    <flow name="VM_onErrorContinueListener" initialState="stopped">
+        <vm:listener queueName="transientQueue" config-ref="VM_Config">
+            <vm:response>
+                <vm:content>
+                    #[lower(payload.salute)]
+                </vm:content>
+            </vm:response>
+        </vm:listener>
+        <set-variable value="dummy" variableName="dummy" />
+        <error-handler >
+            <on-error-continue >
+                <logger />
+            </on-error-continue>
+        </error-handler>
+    </flow>
+
+    <flow name="VM_onErrorPropagateListener" initialState="stopped">
+        <vm:listener queueName="onErrorPropagate" config-ref="onError" />
+        <set-variable value="dummy" variableName="dummy" />
+        <error-handler >
+            <on-error-propagate type="VM:PUBLISH_CONSUMER_FLOW_ERROR">
+                <logger />
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+
+    <flow name="VM_failListener" initialState="stopped">
+        <vm:listener queueName="persistentQueue" config-ref="VM_Config" />
+        <raise-error type="ROUTING" />
+    </flow>
+
+</mule>

--- a/src/test/munit/VMPublishTestCase.xml
+++ b/src/test/munit/VMPublishTestCase.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:tracing="http://www.mulesoft.org/schema/mule/tracing"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/tracing http://www.mulesoft.org/schema/mule/tracing/current/mule-tracing.xsd">
+
+    <munit:config name="VMPublishTestCase.xml" />
+
+    <munit:test name="publish-to-transient-test" description="Test the Publish operation to a transient queue">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow-for-publish" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "text": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish queueName="transientQueue" config-ref="VM_Config">
+                <vm:content>#[vars.payload]</vm:content>
+            </vm:publish>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::equalTo(vars.payload)]"/>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('transientQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-to-persistent-test" description="Test the Publish operation to a persistent queue">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-persistent-queue-flow-for-publish" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <ee:transform doc:name="Transform Message">
+                <ee:message>
+                    <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "text": "Hello"
+}]]></ee:set-payload>
+                </ee:message>
+            </ee:transform>
+            <set-variable doc:name="Set Variable" variableName="payload" value="#[payload]" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish queueName="persistentQueue" config-ref="VM_Config">
+                <vm:content>#[vars.payload]</vm:content>
+            </vm:publish>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::equalTo(vars.payload)]"/>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::withMediaType('application/json')]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('persistentQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-with-default-correlation-id-test" description="Test the publish operation with the default correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow-for-publish" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <tracing:with-correlation-id correlationId="#['myCorrelationId']">
+                <vm:publish queueName="transientQueue" config-ref="VM_Config">
+                    <vm:content><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "text": "Hello"
+}]]></vm:content>
+                </vm:publish>
+            </tracing:with-correlation-id>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.attributes.correlationId]"
+                                     is="#[MunitTools::equalTo('myCorrelationId')]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('transientQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-with-custom-correlation-id-test" description="Test the publish operation with a custom correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow-for-publish" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <set-variable variableName="customCorrelationId" value="customCorrId" />
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish queueName="transientQueue" config-ref="VM_Config" correlationId="customCorrId">
+                <vm:content><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "text": "Hello"
+}]]></vm:content>
+            </vm:publish>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.attributes.correlationId]"
+                                     is="#[MunitTools::equalTo(vars.customCorrelationId)]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('transientQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="never-send-correlation-id-with-publish-operation-test" description="Test the publish operation and never send a correlationId">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-transient-queue-flow-for-publish" />
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <vm:publish queueName="transientQueue" config-ref="VM_Config" correlationId="myCorrId" sendCorrelationId="NEVER">
+                <vm:content><![CDATA[%dw 2.0
+output application/json
+ ---
+{
+    "text": "Hello"
+}]]></vm:content>
+            </vm:publish>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.attributes.correlationId]"
+                                     is="#[MunitTools::not(MunitTools::equalTo('myCorrId'))]"/>
+            <munit-tools:assert-that expression="#[payload.attributesClassType]"
+                                     is="#[MunitTools::equalTo('org.mule.extensions.vm.api.VMMessageAttributes')]"/>
+            <munit-tools:assert-that expression="#[payload.attributes.queueName]"
+                                     is="#[MunitTools::equalTo('transientQueue')]"/>
+            <munit-tools:assert-that expression="#[now() as String {format: 'y-MM-dd:hh:mm:ss'}]"
+                                     is="#[MunitTools::greaterThanOrEqualTo(payload.attributes.timestamp as DateTime as String {format: 'y-MM-dd:hh:mm:ss'})]"/>
+        </munit:validation>
+    </munit:test>
+
+    <flow name="vm-listener-transient-queue-flow-for-publish">
+        <vm:listener config-ref="VM_Config" queueName="transientQueue"/>
+        <munit-tools:store key="listenerData">
+            <munit-tools:value ><![CDATA[#[
+            output application/json
+            ---
+            {
+                "payload": payload,
+                "attributes": message.attributes,
+                "attributesClassType": message.attributes.^class
+            }
+            ]]]></munit-tools:value>
+        </munit-tools:store>
+    </flow>
+
+    <flow name="vm-listener-persistent-queue-flow-for-publish">
+        <vm:listener config-ref="VM_Config" queueName="persistentQueue"/>
+        <munit-tools:store key="listenerData">
+            <munit-tools:value ><![CDATA[#[
+            output application/json
+            ---
+            {
+                "payload": payload,
+                "attributes": message.attributes,
+                "attributesClassType": message.attributes.^class
+            }
+            ]]]></munit-tools:value>
+        </munit-tools:store>
+    </flow>
+
+</mule>

--- a/src/test/munit/VMRedeliveryTestCase.xml
+++ b/src/test/munit/VMRedeliveryTestCase.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:os="http://www.mulesoft.org/schema/mule/os"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/os http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
+
+    <munit:config name="VMRedeliveryTestCase.xml" />
+
+    <os:object-store name="Object_store_redelivery" />
+
+    <munit:test name="redelivery-test" description="Test the redelivery scenario">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="redeliveryListener" />
+        </munit:enable-flow-sources>
+        <munit:behavior >
+            <os:store key="redeliveryCount" objectStore="Object_store_redelivery">
+                <os:value ><![CDATA[#[0]]]></os:value>
+            </os:store>
+        </munit:behavior>
+        <munit:execution>
+            <vm:publish queueName="persistentQueue" config-ref="VM_Config">
+                <vm:content>#["message"]</vm:content>
+            </vm:publish>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <os:retrieve key="redeliveryExhausted" objectStore="Object_store_redelivery"/>
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo(true)]"/>
+            <os:retrieve key="redeliveryCount" objectStore="Object_store_redelivery"/>
+            <munit-tools:assert-that expression="#[payload]"
+                                     is="#[MunitTools::equalTo(4)]"/>
+        </munit:validation>
+    </munit:test>
+
+    <flow name="redeliveryListener">
+        <vm:listener config-ref="VM_Config" queueName="persistentQueue" transactionalAction="ALWAYS_BEGIN">
+            <redelivery-policy maxRedeliveryCount="3"/>
+        </vm:listener>
+
+        <raise-error type="ANY:EXPECTED_ERROR_RAISED" />
+        <error-handler>
+            <on-error-propagate type="REDELIVERY_EXHAUSTED">
+                <os:store objectStore="Object_store_redelivery" key="redeliveryExhausted">
+                    <os:value ><![CDATA[#[true]]]></os:value>
+                </os:store>
+            </on-error-propagate>
+            <on-error-propagate>
+                <os:retrieve key="redeliveryCount" objectStore="Object_store_redelivery"/>
+                <os:store objectStore="Object_store_redelivery" key="redeliveryCount">
+                    <os:value ><![CDATA[#[payload as Number +1]]]></os:value>
+                </os:store>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+
+</mule>

--- a/src/test/munit/VMTxTestCase.xml
+++ b/src/test/munit/VMTxTestCase.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+
+    <munit:config name="VMTxTestCase.xml" >
+        <munit:parameterizations>
+            <munit:parameterization name="transientQueueType">
+                <munit:parameters>
+                    <munit:parameter propertyName="queueName" value="transientQueue"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="persistentQueueType">
+                <munit:parameters>
+                    <munit:parameter propertyName="queueName" value="persistentQueue"/>
+                </munit:parameters>
+            </munit:parameterization>
+        </munit:parameterizations>
+    </munit:config>
+
+    <munit:test name="publish-commit-test" description="Test the publish commit scenario">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-queue-flow" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <set-variable variableName="fail" value="#[false]" />
+        </munit:behavior>
+        <munit:execution>
+            <flow-ref name="VM_publishInTx"/>
+            <until-successful maxRetries="10"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.payload]"
+                                     is="#[MunitTools::equalTo('Hello')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="publish-rollback-test" expectedErrorType="MUNIT-TOOLS:MISSING_KEY" description="Test the publish rollback scenario">
+        <munit:enable-flow-sources >
+            <munit:enable-flow-source value="vm-listener-queue-flow" />
+        </munit:enable-flow-sources>
+        <munit:behavior>
+            <set-variable variableName="fail" value="#[true]" />
+        </munit:behavior>
+        <munit:execution>
+            <try>
+                <flow-ref name="VM_publishInTx"/>
+                <error-handler>
+                    <on-error-continue type="ANY:EXPECTED_ERROR_RAISED"/>
+                </error-handler>
+            </try>
+            <until-successful maxRetries="5"  millisBetweenRetries="2000">
+                <munit-tools:retrieve key="listenerData" />
+            </until-successful>
+        </munit:execution>
+    </munit:test>
+
+    <flow name="vm-listener-queue-flow">
+        <vm:listener config-ref="VM_Config" queueName="${queueName}"/>
+        <munit-tools:store key="listenerData">
+            <munit-tools:value ><![CDATA[#[
+            output application/json
+            ---
+            {
+                "payload": payload,
+                "payloadMimeType": payload.^mimeType,
+                "payloadClassType": payload.^class,
+                "attributes": message.attributes,
+                "attributesClassType": message.attributes.^class
+            }
+            ]]]></munit-tools:value>
+        </munit-tools:store>
+    </flow>
+
+    <flow name="VM_publishInTx">
+        <try transactionalAction="BEGIN_OR_JOIN">
+            <vm:publish queueName="${queueName}" config-ref="VM_Config">
+                <vm:content>#["Hello"]</vm:content>
+            </vm:publish>
+            <flow-ref name="VM_fail" />
+            <error-handler>
+                <on-error-propagate type="ANY:EXPECTED_ERROR_RAISED"/>
+            </error-handler>
+        </try>
+    </flow>
+
+    <sub-flow name="VM_fail">
+        <choice>
+            <when expression="#[vars.fail]">
+                <raise-error type="ANY:EXPECTED_ERROR_RAISED" />
+            </when>
+        </choice>
+    </sub-flow>
+
+</mule>


### PR DESCRIPTION
commit dbdba1d21dc250e4b6774dd0ca33326243ff90ca
Author: Tomás Toloza <tomasezequieltoloza@gmail.com>
Date:   Fri Dec 15 16:38:02 2023 -0300

    Update pom.xml

commit 234ddabf99b05da9ceec539704a627cae0cc0970
Author: Tomás Toloza <tomasezequieltoloza@gmail.com>
Date:   Fri Dec 15 08:47:50 2023 -0300

    Update test connectors dependencies

commit 327bd80c3e9d15d98fb9b9d3a71a9fa60e9931f4
Merge: 25e2381 d8f3c98
Author: alexandruatomei9 <alexandruatomei9@gmail.com>
Date:   Thu Dec 14 15:48:36 2023 +0200

    Merge branch 'support/2.0.x' into feature/release-2.0.1

commit 25e23810643c6a4728c722c7da1c89502bf1ab93
Author: Alex Atomei <alexandruatomei9@gmail.com>
Date:   Thu Dec 14 15:41:40 2023 +0200

    W-14121217 | Preparing release for Java 17 support

commit 2f2341a573dc0d6f1031c4180698691da6fb564a
Author: Alex Atomei <alexandruatomei9@gmail.com>
Date:   Thu Dec 14 15:32:46 2023 +0200

    W-14121217 | Preparing release for Java 17 support

commit a47c7bf240a68f9c984138acb54a3e452ca9b8e8
Author: Tomás Toloza <tomasezequieltoloza@gmail.com>
Date:   Fri Nov 17 11:09:46 2023 -0300

    W-14479342 Increase version for snapshot (#94)

    * Increase version for snapshot

    * Update pom.xml

commit 3f3c26c86c170dd02ff4be8379a8ff2212afaa3c
Author: luizamujdei <luizamujdei@users.noreply.github.com>
Date:   Thu Nov 16 16:15:13 2023 +0200

    Feature/jdk 17 validation (#93)

    * W-13895672 | increase-coverage-java17

    * update jacoco version and fix a munit test

    * jackson version removed

    * jackson version removed

    * munit tests

    * publish correlationId and consume message test cases

    * W-13895672 added munit test for QueueNamesValueProvider

    * W-13895672 | Add munit test case for VMPublishTestCase.java

    * W-13895672 migrated to munit VMConsumeFromQueueWithListenerTestCase

    * W-13895672 | Add munit test cases

    * W-13895672 | Add new line at end of files

    * W-14121214 - java 17 support

    * Fixed runtime version and sdk-api version

    * Fixed failing test and increased the file connector version

    ---------

    Co-authored-by: chodorog <chodorog@salesforce.com>
    Co-authored-by: luciancaba <lucian.caba@softvision.com>
    Co-authored-by: Lucian Caba <102729148+luciancaba@users.noreply.github.com>
    Co-authored-by: Alex Atomei <alexandruatomei9@gmail.com>

commit aed067064e7650cd715325d5953c489b5c7d942c
Author: MarinaKevorkyan <106099659+MarinaKevorkyan@users.noreply.github.com>
Date:   Thu Feb 9 14:57:22 2023 -0300

    W-12436158: Add codeowners, renovate and pr text to .github (#87)

    * W-12436158: add codeowners

    * W-12436158: add renovate

    * W-12436158: add pr text

    * Update and rename CODEOWNERS.txt to CODEOWNERS

commit e3a53a46c574836fe805ddfa4e7ec5ef77e79fc6
Merge: 2ae9c5e 0cae252
Author: MarinaKevorkyan <106099659+MarinaKevorkyan@users.noreply.github.com>
Date:   Tue Dec 6 16:01:30 2022 -0300

    Merge pull request #86 from mulesoft/chore/W-12142616

    W-12142616: Pull request template

commit 0cae252fc07892337f6c7eb2c4b671e1ec756278
Author: MarinaKevorkyan <mkevorkyan@mulesoft.com>
Date:   Tue Dec 6 10:24:16 2022 -0300

    W-12142616: Pull request template

commit 2ae9c5e33057e567976dea69230a6aa8866ba5d5
Author: Alejandro Curci <76498083+acurci-at-mulesoft@users.noreply.github.com>
Date:   Tue Oct 19 12:12:12 2021 -0300

    COCO-50: upgraded core-modules-parent to 1.1.9 (#83)

commit fb68385aa86d40d425ef48f16ee49f27e14579b2
Author: Alejandro Iannucci <4360246+aiannucci@users.noreply.github.com>
Date:   Wed Mar 10 13:35:15 2021 -0300

    DEL-2793: Fix & Update formatter-maven-plugin (#82)

commit 86a898bfea19f1be2e0c8ba9a897e9f0b1599238
Author: Alejandro Curci <76498083+acurci-at-mulesoft@users.noreply.github.com>
Date:   Mon Jan 18 09:45:14 2021 -0300

    VMCON-3: renovate settings for ignoring monthly builds (#80)

commit 8c91e09fbab1957fea84befded5ddd1b3e850bfc
Author: Linda Vanessa Zapata Henao <linda.zapata@mulesoft.com>
Date:   Fri Jul 31 23:17:57 2020 -0300

    DEL-424: Update mule-core-modules-parent version to 1.1.8 to be able to use the GPG fix (#75)

commit 9b7180e4e7c9430efbbd6bc28beea5e17097e8aa
Author: Gustavo Adolfo Rodríguez Libreros <1432287+garodriguezlp@users.noreply.github.com>
Date:   Thu Jul 30 14:36:30 2020 -0500

    DEL-671: Move runtimeBuild pipeline config on projects to yaml format (#74)

commit 72c4d8ec340e4f4dbf9b25f95f30793dfbf15e15
Author: Rodrigo Merino <elrodro83@users.noreply.github.com>
Date:   Mon Feb 3 11:52:15 2020 -0300

    MULE-18023: Remove spring repo declaration in poms (#68)

commit a70ccd5c118ad9a188e26784707a71c16007d66f
Author: Linda Vanessa Zapata Henao <linda.zapata@mulesoft.com>
Date:   Mon Jan 13 22:31:00 2020 -0500

    MULE-17941: Add the project type in Jenkinsfile (#67)

commit 31218c223c5422ec68e7fdde2abd753011973d35
Author: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
Date:   Thu Nov 28 11:29:52 2019 -0300

    Add renovate.json (#64)

commit 6eb7f21a507fadc90029fb440ca05140aeaaaf87
Author: Linda Vanessa Zapata Henao <linda.zapata@mulesoft.com>
Date:   Sun Sep 15 01:22:47 2019 -0500

    MULE-17121: Upgrade mule-extensions-patent, mule-core-modules-parent and mule-ee-core-modules-parent to 1.1.6 (#63)

commit 880d72a94b696f6693a460aa758210c724b67cf9
Author: Rodrigo Merino <elrodro83@users.noreply.github.com>
Date:   Fri Jun 28 14:38:21 2019 -0300

    MULE-17077 :Add tests for persistent queues with transactions (#62)

commit 47293f3ced959bbd2dd6662fe145900ff9a86cb2
Author: Sebastian Elizalde <sebi.elizalde@gmail.com>
Date:   Mon May 6 12:00:22 2019 -0300

    MULE-14556: Add Icons in all the extensions.

commit 704f032749745110f742f1a0bfba84866c0cb1cf
Author: Alejandro Iannucci <4360246+aiannucci@users.noreply.github.com>
Date:   Mon Apr 1 19:33:48 2019 -0700

    MULE-16632: Add missing MediaType to VM connector (#59)

commit 9880e7a5c69484b4a3381d7fdfc7df1b496c2898
Author: anosenzo <anosenzo@users.noreply.github.com>
Date:   Wed Dec 26 19:46:24 2018 -0300

    Update version to 2.1.0-SNAPSHOT (#58)

commit fa40b8c223a075accee7e5ad75d115495d11b160
Author: Alejandro Iannucci <4360246+aiannucci@users.noreply.github.com>
Date:   Thu Nov 8 12:02:42 2018 -0300

    MULE-16005: Update parent POM and dependencies (#57)

commit 27cfee7b5fd1d2373cb8884f042321e6613044a2
Author: Alejandro Iannucci <4360246+aiannucci@users.noreply.github.com>
Date:   Mon Oct 29 18:27:48 2018 -0300

    MULE-15814: Add Jenkinsfile (#56)

commit 08ac863dc7a639f9dacfd19704ee34a5b397636f
Author: anosenzo <anosenzo@users.noreply.github.com>
Date:   Mon Oct 1 19:59:58 2018 -0300

    MULE-15766: Update mule-extensions-parent and mule-extensions-maven-plugin with the fix versions of the maven-install-plugin and maven-deploy-plugin (#55)

_Hi, thank you for your work. We understand that you want to merge your changes and move on from this issue, but we also want to maintain the safety, readability, and testability of our code. Because of this, we kindly ask that you confirm that you have fulfilled the prerequisites for each category of activity before merging your changes._

### If the Pull Request has a dependency update:

- [ ] I have read the Release Notes for the new version (and intermediate versions if the jump would include more than one). _Don't blindly trust that the dependency will honor SEMVER, always read carefully the release notes_
- [ ] Java 8+ support is maintained
- [ ] The new version has no vulnerabilities
- [ ] A team member reviewed the Pull Request.
- [ ] No backward compatibility is broken.
- [ ] If it is a "provided" dependency, it has been checked that if it is suggested, the version number is the same.

### For ALL the Releases:

- [ ] There is a task in GUS for this change.
- [ ] The corresponding Release Notes have been written and shared with the documentation team.
- [ ] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.
- [ ] If you are using reflection, create a test to call the methods you are invoking, this way, if there is a change in the API, the test will be able to detect it.
- [ ] If the project has a parent pom and modules, the release pipeline only uploads the modules, so, please, make sure that the parent was deployed in the repositories before considering this release finished.
- [ ] Notify in the Slack Channel that the release is complete, so the Docs team can merge the Documentation and Release Notes PR. The docs team always checks in Anypoint Exchange that the connector is released before merging the release notes.
- [ ] Add the connector build to GUS, and assign that build to the GUS ticket.
- [ ] Create a change case request, based on the Change Case Management doc https://docs.google.com/document/d/1tMJlTTZLaXMLiYwxlMBFY1yJwBmejhc4-IP8HAXgDfY/edit#

**NOTE**: _(applies only for Core-Connectors connectors and modules) The release process ends when you merge the pull request that updates the support branch to the new snapshot, please don't forget to do this._

### Patch Version:

- [ ] The Pull Request has been peer-reviewed.
- [ ] No backward compatibility is broken.
- [ ] Documentation: (Required) Release Notes PR with compatibility table. Share it with the Docs team.

### Minor Version:

- [ ] Have a document with the specification of the release.
- [ ] Create a slack channel (eg: rl-conninfra-sftp-1.1.1-new-chiper) to coordinate the release of this version with the documentation team and the architects of our team (at least one week before the release). Share the spec doc with the docs team.
- [ ] The documentation fork has been done and has been updated with the changes related to the new functionalities.
- [ ] The pull request has been reviewed by a peer and the team leader.
- [ ] No backward compatibility is broken.
- [ ] Public Documentation: Minor releases nearly always require a revision of the documentation because the release usually includes new features as well as bug fixes. Even if there are no user-facing changes, documentation has to be versioned for every minor release.
  - [ ] (Required) Release Notes PR with compatibility table. Share it with the Docs team.
  - [ ] (Likely required) Reference guide. Run the script and share the file with the Docs team.
  - [ ] (Assess) Often a minor release impacts UI and examples, so the documentation (user guides, examples, troubleshooting guides) should be reviewed and updated accordingly. Notify the docs team if any updates are needed.

### Major Version:

- [ ] Have a document with the specification of the release.
- [ ] Create a slack channel (eg: rl-conninfra-sftp-2.0.0) to coordinate the release of this version with the documentation team and the architects of our team (at least one month before the release). Share the spec doc with the docs team.
- [ ] The documentation fork has been made and updated with the changes related to the new functionalities and possible compatibility problems with the previous version.
- [ ] The systems properties have been removed, detailing in the documentation the changes in the default behavior of the product.
- [ ] The TODO comments of the code have been reviewed.
- [ ] A colleague, the team leader, and the team architect have reviewed the Pull Request.
- [ ] Public Documentation: Major releases break backward compatibility and should never be released without documentation, as this breaks the user experience.
  - [ ] (Required) Upgrade and Migration Guide: Every major release must have a detailed upgrade guide (template) with information about what was changed and what steps the user has to take to ensure the connector works as expected. Share the details with the Docs team so they can update the guide.
  - [ ] (Required) Release Notes PR with compatibility table. Share it with the docs team.
  - [ ] (Required) Reference guide. Run the script and share the file with the Docs team.
  - [ ] User guide updates, new screenshots or examples (if applicable), share the updates with the docs team.
